### PR TITLE
Feature/package versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 #Changelog
 - - -
 
+###version 0.1.1 (unreleased)
+
+* Added package versioning support
+
 ###version 0.1 (March 13th, 2015)
 
 * Added Heka installation via packages, init script/systemd unit file templating and service management

--- a/README.md
+++ b/README.md
@@ -105,10 +105,12 @@ To specify a particular Heka package version to install, use the `package_downlo
 
 ```bash
 class { '::heka':
-  version => '0.9.1',
-  package_download_url => 'https://github.com/mozilla-services/heka/releases/download/v0.9.1/heka-0_9_1-linux-amd64.rpm',
+  version => '0.9.2',
+  package_download_url => 'https://github.com/mozilla-services/heka/releases/download/v0.9.2/heka-0_9_2-linux-amd64.rpm',
 }
 ```
+
+If you specify an older version than what is currently installed, the module will downgrade the package. However, make sure that the plugins and configuration options you're specifying with the module's plugin types are compatible with the version you are downgrading to!
 
 ####[Puppet parameter and Heka data types](id:parameter-data-types)
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ class { '::heka':
 }
 ```
 
+####Package versioning
+
+To specify a particular Heka package version to install, use the `package_download_url` and `version` parameters:
+
+```bash
+class { '::heka':
+  version => '0.9.1',
+  package_download_url => 'https://github.com/mozilla-services/heka/releases/download/v0.9.1/heka-0_9_1-linux-amd64.rpm',
+}
+```
+
 ####[Puppet parameter and Heka data types](id:parameter-data-types)
 
 **Booleans**

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,6 +5,7 @@
 # === Parameters
 #
 # @param package_download_url String; the URL of the RPM/DEB package to install.
+# @param version String; the version of Heka being installed; right now, this is just used to create unique file names for each package version that gets downloaded and to reference it in the package resource that installs Heka
 # @param manage_service Bool; whether to have the module manage the Heka daemon. defaults to `true`
 # @param service_ensure String; the state the Heka daemon should be set to; defaults to `running`
 # @param service_enable Bool; whether the Heka daemon should be enabled to start on system boot; defaults to `true`
@@ -22,6 +23,7 @@
 
 class heka (
   $package_download_url   = $heka::params::package_download_url,
+  $version                = $heka::params::version,
   $manage_service         = $heka::params::manage_service,
   $service_ensure         = $heka::params::service_ensure,
   $service_enable         = $heka::params::service_enable,
@@ -47,6 +49,7 @@ class heka (
     #Like the class chain above, but without the `class { 'heka::service': }`.
     class { 'heka::install':
       package_download_url => $package_download_url,
+      version => $version,
     } ~>
     class { 'heka::config': }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,6 +39,7 @@ class heka (
     #class on the right.
     class { 'heka::install':
       package_download_url => $package_download_url,
+      version => $version,
     } ~>
     class { 'heka::config': 
       global_config_settings => $global_config_settings

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,6 +5,7 @@
 # === Parameters
 #
 # @param package_download_url String; the URL of the RPM/DEB package to install; defaults to `$heka::params::package_download_url`
+# @param version String; the version of Heka being installed; right now, this is just used to create unique file names for each package version that gets downloaded and to reference it in the package resource that installs Heka
 #
 # === Examples
 #
@@ -17,30 +18,31 @@
 
 class heka::install (
   $package_download_url = $heka::params::package_download_url,
+  $version = $heka::params::version,
 ) inherits heka::params {
 
   case $::operatingsystem {
     'RedHat', 'CentOS': {
       #Download the package first
-      staging::file { 'heka-package':
+      staging::file { "heka-package_${version}.rpm":
         source => $package_download_url,
       } ~>
       #...then install it:
       package { 'heka':
-        ensure   => 'installed',
-        source   => '/opt/staging/heka/heka-package',
+        ensure   => 'latest',
+        source   => "/opt/staging/heka/heka-package_${version}.rpm",
         provider => $package_provider,
       }
     }
     'Debian', 'Ubuntu': {
       #Download the package first
-      staging::file { 'heka-package':
+      staging::file { "heka-package_${version}.deb":
         source => $package_download_url,
       } ~>
       #...then install it:
       package { 'heka':
-        ensure   => 'installed',
-        source   => '/opt/staging/heka/heka-package',
+        ensure   => 'latest',
+        source   => "/opt/staging/heka/heka-package_${version}.deb",
         provider => $package_provider,
       }
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,8 @@
 
 class heka::params {
 
+  $version = '0.9.1'
+
   ##############################
   # Heka general parameters
   ##############################
@@ -38,13 +40,13 @@ class heka::params {
     'RedHat', 'CentOS': {
      #Pick the right package provider:
       $package_provider = 'rpm'
-      $package_download_url = 'https://github.com/mozilla-services/heka/releases/download/v0.8.3/heka-0_8_3-linux-amd64.rpm'
+      $package_download_url = 'https://github.com/mozilla-services/heka/releases/download/v0.9.1/heka-0_9_1-linux-amd64.rpm'
     }
     #Debian/Ubuntu systems:
     'Debian', 'Ubuntu': {
      #Pick the right package provider:
       $package_provider = 'dpkg'
-      $package_download_url = 'https://github.com/mozilla-services/heka/releases/download/v0.8.3/heka_0.8.3_amd64.deb'
+      $package_download_url = 'https://github.com/mozilla-services/heka/releases/download/v0.9.1/heka_0.9.1_amd64.deb'
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,7 +13,7 @@
 
 class heka::params {
 
-  $version = '0.9.1'
+  $version = '0.9.2'
 
   ##############################
   # Heka general parameters
@@ -40,13 +40,13 @@ class heka::params {
     'RedHat', 'CentOS': {
      #Pick the right package provider:
       $package_provider = 'rpm'
-      $package_download_url = 'https://github.com/mozilla-services/heka/releases/download/v0.9.1/heka-0_9_1-linux-amd64.rpm'
+      $package_download_url = 'https://github.com/mozilla-services/heka/releases/download/v0.9.2/heka-0_9_2-linux-amd64.rpm'
     }
     #Debian/Ubuntu systems:
     'Debian', 'Ubuntu': {
      #Pick the right package provider:
       $package_provider = 'dpkg'
-      $package_download_url = 'https://github.com/mozilla-services/heka/releases/download/v0.9.1/heka_0.9.1_amd64.deb'
+      $package_download_url = 'https://github.com/mozilla-services/heka/releases/download/v0.9.2/heka_0.9.2_amd64.deb'
     }
   }
 


### PR DESCRIPTION
Sidekick @intjonathan 

I bumped up the default version to the current one, v0.9.2

This should take care of https://github.com/newrelic/puppet-heka/issues/3
