### PR TITLE
Make management of the Heka daemon optional, but default to managing it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,21 @@ This module requires the following Puppet modules:
 
 ###[Basic usage](id:basic-usage)
 
-The following installs and configures Heka with it's default settings. The `maxprocs` in Heka's main config will be set to the value of the `processorcount` fact. All other global config values won't be printed in the main config file unless specified as parameters. If they aren't printed in the file, Heka will use its own internal default value for each setting.
+The following installs and configures Heka with it's default settings and manages the Heka daemon once everything is installed and configured. The `maxprocs` in Heka's main config will be set to the value of the `processorcount` fact. All other global config values won't be printed in the main config file unless specified as parameters. If they aren't printed in the file, Heka will use its own internal default value for each setting.
 
 ```bash
 class { '::heka':}
 ```
+
+You can optionally choose to not manage the Heka service:
+
+```bash
+class { '::heka':
+  manage_service => false,
+}
+```
+
+**Note:** The value of this parameter is also used as the default for any plugins configured by the module and will control whether they try to notify the Heka daemon. If the Heka service is not managed by the main `heka` class, make sure that you don't explicitly set any plugins to notify the daemon with their `refresh_heka_service` parameter. If you do, catalog compilation will fail, as the Heka service won't be in the catalog for the plugin to send notifications to. 
 
 To specify a custom configuration option the module doesn't provide an explicit parameter for, use the `global_config_settings` parameter: 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -39,7 +39,8 @@ class heka (
       package_download_url => $package_download_url,
     } ~>
     class { 'heka::config': 
-      global_config_settings => $global_config_settings
+      global_config_settings => $global_config_settings,
+      manage_service         => $manage_service
     } ~>
     class { 'heka::service': }
   }
@@ -48,7 +49,10 @@ class heka (
     class { 'heka::install':
       package_download_url => $package_download_url,
     } ~>
-    class { 'heka::config': }
+    class { 'heka::config': 
+      global_config_settings => $global_config_settings,
+      manage_service         => $manage_service
+    }
   }
 
 }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -39,7 +39,7 @@ define heka::plugin (
   $plugin_file_group    = 'root',
   $plugin_file_mode     = '0644',
   $plugin_file_template = 'heka/plugins/heka_plugin.toml.erb',
-  $refresh_heka_service = true,
+  $refresh_heka_service = $heka::manage_service,
   $heka_daemon_name     = 'heka',
   $type                 = undef,
   $settings             = {},

--- a/manifests/plugin/input/stataccuminput.pp
+++ b/manifests/plugin/input/stataccuminput.pp
@@ -53,7 +53,7 @@ define heka::plugin::input::stataccuminput (
   $plugin_file_owner    = 'root',
   $plugin_file_group    = 'root',
   $plugin_file_mode     = '0644',
-  $refresh_heka_service = true,
+  $refresh_heka_service = $heka::manage_service,
   $heka_daemon_name     = 'heka',
   #stataccuminput plugin specific parameters
   $plugin_file_template = 'heka/plugins/inputs/heka_stataccuminput_plugin.toml.erb',

--- a/manifests/plugin/input/statsdinput.pp
+++ b/manifests/plugin/input/statsdinput.pp
@@ -47,7 +47,7 @@ define heka::plugin::input::statsdinput (
   $plugin_file_owner    = 'root',
   $plugin_file_group    = 'root',
   $plugin_file_mode     = '0644',
-  $refresh_heka_service = true,
+  $refresh_heka_service = $heka::manage_service,
   $heka_daemon_name     = 'heka',
   #statsdinput plugin specific parameters
   $plugin_file_template = 'heka/plugins/inputs/heka_statsdinput_plugin.toml.erb',

--- a/manifests/plugin/input/tcpinput.pp
+++ b/manifests/plugin/input/tcpinput.pp
@@ -47,7 +47,7 @@ define heka::plugin::input::tcpinput (
   $plugin_file_owner    = 'root',
   $plugin_file_group    = 'root',
   $plugin_file_mode     = '0644',
-  $refresh_heka_service = true,
+  $refresh_heka_service = $heka::manage_service,
   $heka_daemon_name     = 'heka',
   #TcpInput plugin specific parameters
   $plugin_file_template = 'heka/plugins/inputs/heka_tcpinput_plugin.toml.erb',

--- a/manifests/plugin/input/udpinput.pp
+++ b/manifests/plugin/input/udpinput.pp
@@ -46,7 +46,7 @@ define heka::plugin::input::udpinput (
   $plugin_file_owner    = 'root',
   $plugin_file_group    = 'root',
   $plugin_file_mode     = '0644',
-  $refresh_heka_service = true,
+  $refresh_heka_service = $heka::manage_service,
   $heka_daemon_name     = $heka::params::heka_daemon_name,
   #udpinput plugin specific parameters
   $plugin_file_template = 'heka/plugins/inputs/heka_udpinput_plugin.toml.erb',

--- a/manifests/plugin/output/carbonoutput.pp
+++ b/manifests/plugin/output/carbonoutput.pp
@@ -45,7 +45,7 @@ define heka::plugin::output::carbonoutput (
   $plugin_file_owner    = 'root',
   $plugin_file_group    = 'root',
   $plugin_file_mode     = '0644',
-  $refresh_heka_service = true,
+  $refresh_heka_service = $heka::manage_service,
   $heka_daemon_name     = 'heka',
   #CarbonOutput plugin specific parameters
   $plugin_file_template = 'heka/plugins/outputs/heka_carbonoutput_plugin.toml.erb',


### PR DESCRIPTION
Also changed the default value of the refresh_heka_service parameters on each of the plugin defined types so that they would use the same value as what the main class has set. This will help prevent catalog compilation failures where a user says not to manage the Heka service in the main class but doesn't also explicitly set refresh_heka_service in their plugin definitions to false.

This fixes https://github.com/newrelic/puppet-heka/issues/5

Sidekick @intjonathan 
