### PR TITLE
Fail catalog compilation if the user leaves the $type parameter undef…

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ You can use the `heka::plugin` defined type to generate TOML configs for plugins
 }
 ```
 
-The `type` parameter is required.
+**Note:** The `type` parameter is required.
 
 **Settings**
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -54,9 +54,14 @@ define heka::plugin (
   validate_string($plugin_file_name)
   validate_string($plugin_file_template)
   validate_string($heka_daemon_name)
-  validate_string($type)
   validate_hash($settings)
   validate_hash($subsetting_sections)
+  
+  #Fail if the user leaves the $type parameter empty:
+  if $type == undef {
+    fail('The $type parameter cannot be empty!')
+  }
+
 
  #If the refresh_heka_service parameter is set to true...
   if $refresh_heka_service == true {


### PR DESCRIPTION
…ined. Heka requires the type parameter in plugin definitions.

Fixes https://github.com/newrelic/puppet-heka/issues/2
