### PR TITLE
Explicitly set start, stop, restart and status commands for the Heka

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@
 
 ###version 0.2.0 (unreleased)
 
-* [Issue #2](https://github.com/newrelic/puppet-heka/issues/2) and [PR #9](https://github.com/newrelic/puppet-heka/pull/9): Don't allow `type` parameters on custom plugins 
+
+* [Issue #1](https://github.com/newrelic/puppet-heka/issues/1) and [PR #15](https://github.com/newrelic/puppet-heka/pull/15): Explicitly specify **start**, **stop**, **restart** and **status** `initctl` commands when managing the Heka service on CentOS 6. This is a workaround for bugs in the Upstart provider on CentOS 6 in older versions of Puppet 3.x. Also, call `/sbin/initctl reload-configuration` so that Upstart knows about Heka as a service after Puppet creates `/etc/init/heka.conf`.
+* [Issue #2](https://github.com/newrelic/puppet-heka/issues/2) and [PR #9](https://github.com/newrelic/puppet-heka/pull/9): Don't allow `type` parameters on custom plugins
 * [Issue #3](https://github.com/newrelic/puppet-heka/issues/3) and [PR #6](https://github.com/newrelic/puppet-heka/pull/6): Added package versioning support
 * [Issue #5](https://github.com/newrelic/puppet-heka/issues/5) and [PR #8](https://github.com/newrelic/puppet-heka/pull/8): Make management of the Heka service optional.
 * [Issue #10](https://github.com/newrelic/puppet-heka/issues/10) and [PR #11](https://github.com/newrelic/puppet-heka/pull/11): Add the ability to set a custom `maxprocs` value in `/etc/heka.toml`
 * [Issue #13](https://github.com/newrelic/puppet-heka/issues/13) and [PR #14](https://github.com/newrelic/puppet-heka/pull/14): Added the ability to purge unmanaged TOML config files.
+
+
 
 
 ###version 0.1 (March 13th, 2015)

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -64,6 +64,11 @@ class heka::config (
               mode    => '0644',
               content => template('heka/heka.conf.erb'),
               notify  => Service[$heka_daemon_name],
+            } ~>
+            #Run initctl reload-configuration so Upstart knows about the new Heka daemon config file:
+            exec { 'initctl-reload-config-for-heka':
+              command     => "/sbin/initctl reload-configuration",
+              refreshonly => true,
             }
           }
           '7': {


### PR DESCRIPTION
daemon on CentOS 6. This is a workaround for bugs in the Upstart
provider on CentOs 6 in older versions of Puppet 3.

Also, run `/sbin/initctl reload-configuration` after creating the
Upstart config so that Upstart knows about the Heka service and can
manage it.

This fixes https://github.com/newrelic/puppet-heka/issues/1

Sidekick @intjonathan 
