### PR TITLE
Honor version and package_download_url parameter

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -17,8 +17,8 @@
 #
 
 class heka::install (
-  $package_download_url = $heka::params::package_download_url,
-  $version = $heka::params::version,
+  $package_download_url = $heka::package_download_url,
+  $version = $heka::version,
 ) inherits heka::params {
 
   case $::operatingsystem {


### PR DESCRIPTION
If I use heka class and set version and package_download_url parameters the heka::install class should honor these params.
